### PR TITLE
Add CI builds support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI builder
+
+on: [push, pull_request]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: CI builder for listenbrainz-rs
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Perform build of listenbrainz-rs
+      run: cargo build --verbose
+    - name: Run unit tests for listenbrain-rs
+      run: cargo test --verbose


### PR DESCRIPTION
This uses GitHub Actions, it builds listenbrainz-rs and runs unit tests
if applicable.

It is triggered by the following GitHub events:

- A push to the repo
- A PR made to the repo

Of course, it's not strictly necssary to use GitHub Actions; there are
other services.

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>