### PR TITLE
Make fields in UserPlayingNowListen optional

### DIFF
--- a/src/raw/response.rs
+++ b/src/raw/response.rs
@@ -215,9 +215,9 @@ pub struct UserPlayingNowPayload {
 /// Type of the [`UserPlayingNowPayload::listens`] field.
 #[derive(Debug, Deserialize)]
 pub struct UserPlayingNowListen {
-    pub user_name: String,
-    pub inserted_at: String,
-    pub recording_msid: String,
+    pub user_name: Option<String>,
+    pub inserted_at: Option<String>,
+    pub recording_msid: Option<String>,
     pub track_metadata: UserPlayingNowTrackMetadata,
 }
 


### PR DESCRIPTION
when attempting to fetch playingnows from the listenbrainz api, i kept running into errors like Json(Error("missing field inserted_at" because the api wasn't providing those fields at the endpoint for the listens list. i made them optional and it no longer panics.