### PR TITLE
Use generics on raw request structs

### DIFF
--- a/examples/delete_listen.rs
+++ b/examples/delete_listen.rs
@@ -11,7 +11,7 @@ fn main() {
 
     let delete = DeleteListen {
         listened_at: listened_at.parse().unwrap(),
-        recording_msid: &recording_msid,
+        recording_msid,
     };
     let result = client.delete_listen(&token, delete);
     println!("{:#?}", result);

--- a/examples/submit_listens.rs
+++ b/examples/submit_listens.rs
@@ -1,6 +1,6 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use listenbrainz::raw::request::{ListenType, Payload, SubmitListens, TrackMetadata};
+use listenbrainz::raw::request::{Empty, ListenType, Payload, SubmitListens, TrackMetadata};
 use listenbrainz::raw::Client;
 
 fn now() -> i64 {
@@ -17,7 +17,7 @@ fn main() {
 
     // Submit single
 
-    let listen = Payload {
+    let listen: Payload<_> = Payload {
         listened_at: Some(now()),
         track_metadata: TrackMetadata {
             artist_name: "Rick Astley",
@@ -41,7 +41,7 @@ fn main() {
         track_metadata: TrackMetadata {
             artist_name: "Rick Astley",
             track_name: "Never Gonna Give You Up",
-            release_name: None,
+            release_name: None::<Empty>,
             additional_info: None,
         },
     };

--- a/src/raw/client.rs
+++ b/src/raw/client.rs
@@ -1,3 +1,4 @@
+use attohttpc::header::AUTHORIZATION;
 use serde::Serialize;
 
 use super::endpoint::Endpoint;
@@ -96,7 +97,7 @@ impl Client {
         let endpoint = format!("{}{}", self.api_root_url, endpoint);
 
         let response = attohttpc::post(endpoint)
-            .header("Authorization", &format!("Token {}", token))
+            .header(AUTHORIZATION, format!("Token {token}"))
             .json(&data)?
             .send()?;
 
@@ -116,7 +117,9 @@ impl Client {
     pub fn validate_token(&self, token: &str) -> Result<ValidateTokenResponse, Error> {
         let endpoint = format!("{}{}", self.api_root_url, Endpoint::ValidateToken);
 
-        let response = attohttpc::get(endpoint).param("token", token).send()?;
+        let response = attohttpc::get(endpoint)
+            .header(AUTHORIZATION, format!("Token {token}"))
+            .send()?;
 
         ResponseType::from_response(response)
     }

--- a/src/raw/client.rs
+++ b/src/raw/client.rs
@@ -27,13 +27,11 @@ pub struct Client {
 impl Client {
     /// Construct a new client.
     pub fn new() -> Self {
-        Self {
-            api_root_url: API_ROOT_URL.to_string(),
-        }
+        Self::new_with_url(API_ROOT_URL)
     }
 
     /// Construct a new client with a custom API URL.
-    pub fn new_with_url(url: &str) -> Self {
+    pub fn new_with_url(url: impl ToString) -> Self {
         Self {
             api_root_url: url.to_string(),
         }
@@ -105,10 +103,10 @@ impl Client {
     }
 
     /// Endpoint: [`submit-listens`](https://listenbrainz.readthedocs.io/en/production/dev/api/#post--1-submit-listens)
-    pub fn submit_listens(
+    pub fn submit_listens<Track: StrType, Artist: StrType, Release: StrType>(
         &self,
         token: &str,
-        data: SubmitListens,
+        data: SubmitListens<Track, Artist, Release>,
     ) -> Result<SubmitListensResponse, Error> {
         self.post(Endpoint::SubmitListens, token, data)
     }
@@ -125,10 +123,10 @@ impl Client {
     }
 
     /// Endpoint: [`delete-listen`](https://listenbrainz.readthedocs.io/en/production/dev/api/#post--1-delete-listen)
-    pub fn delete_listen(
+    pub fn delete_listen<T: StrType>(
         &self,
         token: &str,
-        data: DeleteListen,
+        data: DeleteListen<T>,
     ) -> Result<DeleteListenResponse, Error> {
         self.post(Endpoint::DeleteListen, token, data)
     }

--- a/src/raw/request.rs
+++ b/src/raw/request.rs
@@ -34,7 +34,7 @@ pub struct Payload<Track: StrType, Artist: StrType = Track, Release: StrType = T
 
 /// Type of the [`Payload::track_metadata`] field.
 ///
-/// If [`release_name`](Self::release_name) will always be [None] and the type for `Release` cannot be inferred, set it to the [Empty] type
+/// If [`release_name`](Self::release_name) will always be [None] and the type for `Release` cannot be inferred, set it to the [Empty] type.
 #[derive(Debug, serde::Serialize)]
 pub struct TrackMetadata<Track: StrType, Artist: StrType = Track, Release: StrType = Track> {
     pub track_name: Track,
@@ -64,11 +64,12 @@ pub struct UpdateLatestImport {
     pub ts: i64,
 }
 
+/// Type for use in generic contexts that want a string. Technically, only [Serialize] is required by the api,
+/// but the [Borrow] constraint makes working with values more convenient in non-write contexts.
 pub trait StrType: Borrow<str> + Serialize {}
 impl<T: Borrow<str> + Serialize> StrType for T {}
 
 /// Dummy type to use as explicit `Release` type if [`TrackMetadata::release_name`] is [None] and its type cannot be inferred.
-/// Creating an instance of this type is not allowed
 /// ```ignore
 /// TrackMetadata {
 ///     ...,
@@ -83,9 +84,8 @@ impl<T: Borrow<str> + Serialize> StrType for T {}
 /// }
 /// ```
 #[allow(missing_debug_implementations)]
-#[non_exhaustive]
 #[derive(Serialize)]
-pub struct Empty;
+pub enum Empty {}
 impl Borrow<str> for Empty {
     fn borrow(&self) -> &str {
         unreachable!("Should never be used as a value")

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -91,9 +91,7 @@ impl ListenBrainz {
         track: &str,
         release: Option<&str>,
     ) -> Result<(), Error> {
-        if !self.is_authenticated() {
-            return Err(Error::NotAuthenticated);
-        }
+        let token = self.authenticated_token().ok_or(Error::NotAuthenticated)?;
 
         let payload = Payload {
             listened_at: timestamp,
@@ -105,7 +103,6 @@ impl ListenBrainz {
             },
         };
 
-        let token = self.authenticated_token().unwrap();
         self.client.submit_listens(
             token,
             SubmitListens {


### PR DESCRIPTION
Changes all `&str` fields in the request module structs to use a generic `StrType` which is defined as:
```rust
pub trait StrType: Borrow<str> + Serialize {}
impl<T: Borrow<str> + Serialize> StrType for T {}
```

Using `&str` for the `TrackMetadata` and other request structs field types makes working with the raw api difficult since it prevents the usage of owned `String`s. Using a generic allows much more flexible client usage since this library only needs the type to be serializable. The additional `Borrow<str>` constraint is added for convenience and usablity.

The `wrapper` interface is unchanged and continues to use `&str`.

The motivation for this was a CLI import tool I made recently where I am mapping deserialized structs into `Payload`s that own their data.