### PR TITLE
Update to the UserListensResponse models to add MBID mapping and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+/.vscode

--- a/src/raw/response.rs
+++ b/src/raw/response.rs
@@ -207,6 +207,7 @@ response_type! {
 pub struct UserListensPayload {
     pub count: u64,
     pub latest_listen_ts: i64,
+    pub oldest_listen_ts: i64,
     pub user_id: String,
     pub listens: Vec<UserListensListen>,
 }

--- a/src/raw/response.rs
+++ b/src/raw/response.rs
@@ -208,12 +208,12 @@ pub struct UserListensPayload {
     /// The count of listen retrived from the database. 
     pub count: u64,
 
-    /// The timestamp of the latest listen of the user.
+    /// The UNIX timestamp of the latest listen of the user.
     ///
     /// ⚠️ This isn't necessarly the latest listen of [`UserListensPayload::listens`] !
     pub latest_listen_ts: i64,
     
-    /// The timestamp of the oldest listen of the user.
+    /// The UNIX timestamp of the oldest listen of the user.
     ///
     /// ⚠️ This isn't necessarly the oldest listen of [`UserListensPayload::listens`] !
     pub oldest_listen_ts: i64,
@@ -228,20 +228,48 @@ pub struct UserListensPayload {
 /// Type of the [`UserListensPayload::listens`] field.
 #[derive(Debug, Deserialize)]
 pub struct UserListensListen {
+    /// The username of the listener.
     pub user_name: String,
+
+    /// The UNIX timestamp of when the listen have been inserted in the database
     pub inserted_at: i64,
+
+    /// The UNIX timestamp of when the recording have been listened to
     pub listened_at: i64,
+    
+    /// Messybrainz ID
     pub recording_msid: String,
+
+    /// Metadata of the track
     pub track_metadata: UserListensTrackMetadata,
 }
 
 /// Type of the [`UserListensListen::track_metadata`] field.
 #[derive(Debug, Deserialize)]
 pub struct UserListensTrackMetadata {
+    /// The name of the artist as it was submited.
+    ///
+    /// ⚠️ User data is unreliable! This may not be correct artist! Check [`UserListensTrackMetadata::mbid_mapping`] for mapping information!
     pub artist_name: String,
+    
+    /// The name of the track as it was submited.
+    ///
+    /// ⚠️ User data is unreliable! This may not be correct artist! Check [`UserListensTrackMetadata::mbid_mapping`] for mapping information!
     pub track_name: String,
+    
+    /// The name of the release as it was submited.
+    ///
+    /// ⚠️ User data is unreliable! This may not be correct artist! Check [`UserListensTrackMetadata::mbid_mapping`] for mapping information!
     pub release_name: Option<String>,
+    
+    /// Additional info that the client submited alongside the request
+    ///
+    /// This can be anything, but see [the listenbrainz documentation](https://listenbrainz.readthedocs.io/en/latest/users/json.html#payload-json-details) for official fields
     pub additional_info: HashMap<String, serde_json::Value>,
+    
+    /// The mapping information between Listenbrainz and Musicbrainz.
+    /// If no mapping could be done, this field will `None`
+    pub mbid_mapping: Option<()>
 }
 
 // --------- latest-import (GET)

--- a/src/raw/response.rs
+++ b/src/raw/response.rs
@@ -280,13 +280,26 @@ pub struct UserListensMBIDMapping {
     artist_mbids: Vec<String>,
 
     /// Data about the artists of the recording
-    artists: Vec<()>,
+    artists: Vec<UserListensMappingArtist>,
 
     /// The MBID of the recording
     recording_mbid: String,
 
     /// The name of the recording
     recording_name: String   
+}
+
+/// Type of the [`UserListensMBIDMapping::artists`] field.
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+pub struct UserListensMappingArtist {
+    /// The MBID of the artists of the recording
+    artist_mbid: String,
+
+    /// The name of the artist as it is credited for the recording
+    artist_credit_name: String,
+
+    /// The join phrase for the artist
+    join_phrase: String,
 }
 
 // --------- latest-import (GET)

--- a/src/raw/response.rs
+++ b/src/raw/response.rs
@@ -249,17 +249,17 @@ pub struct UserListensListen {
 pub struct UserListensTrackMetadata {
     /// The name of the artist as it was submited.
     ///
-    /// ⚠️ User data is unreliable! This may not be correct artist! Check [`UserListensTrackMetadata::mbid_mapping`] for mapping information!
+    /// ⚠️ User data is unreliable! This may not be correct artist! Check [`UserListensTrackMetadata::mbid_mapping`] for trusted information!
     pub artist_name: String,
     
     /// The name of the track as it was submited.
     ///
-    /// ⚠️ User data is unreliable! This may not be correct artist! Check [`UserListensTrackMetadata::mbid_mapping`] for mapping information!
+    /// ⚠️ User data is unreliable! This may not be correct artist! Check [`UserListensTrackMetadata::mbid_mapping`] for trusted information!
     pub track_name: String,
     
     /// The name of the release as it was submited.
     ///
-    /// ⚠️ User data is unreliable! This may not be correct artist! Check [`UserListensTrackMetadata::mbid_mapping`] for mapping information!
+    /// ⚠️ User data is unreliable! This may not be correct artist! Check [`UserListensTrackMetadata::mbid_mapping`] for trusted information!
     pub release_name: Option<String>,
     
     /// Additional info that the client submited alongside the request
@@ -269,7 +269,24 @@ pub struct UserListensTrackMetadata {
     
     /// The mapping information between Listenbrainz and Musicbrainz.
     /// If no mapping could be done, this field will `None`
-    pub mbid_mapping: Option<()>
+    pub mbid_mapping: Option<UserListensMBIDMapping>
+}
+
+
+/// Type of the [`UserListensTrackMetadata::mbid_mapping`] field.
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+pub struct UserListensMBIDMapping {
+    /// The MBIDs of the artists of the recording
+    artist_mbids: Vec<String>,
+
+    /// Data about the artists of the recording
+    artists: Vec<()>,
+
+    /// The MBID of the recording
+    recording_mbid: String,
+
+    /// The name of the recording
+    recording_name: String   
 }
 
 // --------- latest-import (GET)

--- a/src/raw/response.rs
+++ b/src/raw/response.rs
@@ -205,10 +205,23 @@ response_type! {
 /// Type of the [`UserListensResponse::payload`] field.
 #[derive(Debug, Deserialize)]
 pub struct UserListensPayload {
+    /// The count of listen retrived from the database. 
     pub count: u64,
+
+    /// The timestamp of the latest listen of the user.
+    ///
+    /// ⚠️ This isn't necessarly the latest listen of [`UserListensPayload::listens`] !
     pub latest_listen_ts: i64,
+    
+    /// The timestamp of the oldest listen of the user.
+    ///
+    /// ⚠️ This isn't necessarly the oldest listen of [`UserListensPayload::listens`] !
     pub oldest_listen_ts: i64,
+    
+    /// The user id of the listener. 
     pub user_id: String,
+
+    /// The listens of the listener
     pub listens: Vec<UserListensListen>,
 }
 


### PR DESCRIPTION
The current response models lack any MBID mapping information that would appear on the request, making it impossible to determine if the listen is mapped or not.

I've added the missing fields, and added documentation comments for all the other fields of the response.