### PR TITLE
Implemented GET /1/stats/release-group/(release_group_mbid)/listeners

### DIFF
--- a/src/raw/client.rs
+++ b/src/raw/client.rs
@@ -328,6 +328,22 @@ impl Client {
         self.get_stats(Endpoint::StatsUserArtists(user_name), count, offset, range)
     }
 
+    
+    /// Endpoint: [`GET /1/stats/release-group/(release_group_mbid)/listeners`](https://listenbrainz.readthedocs.io/en/latest/users/api/statistics.html#get--1-stats-release-group-(release_group_mbid)-listeners)
+    /// Get the top listeners for a release group, as well as getting the total number of listens for it
+    pub fn stats_release_group_listeners(
+        &self,
+        release_group_mbid: &str,
+        range: Option<&str>,
+    ) -> Result<Option<StatsReleaseGroupListenersResponse>, Error> {
+        self.get_stats(
+            Endpoint::StatsReleaseGroupListeners(release_group_mbid),
+            None,
+            None,
+            range,
+        )
+    }
+
     /// Endpoint: [`status/get-dump-info`](https://listenbrainz.readthedocs.io/en/production/dev/api/#get--1-status-get-dump-info)
     pub fn status_get_dump_info(
         &self,

--- a/src/raw/endpoint.rs
+++ b/src/raw/endpoint.rs
@@ -15,6 +15,7 @@ pub enum Endpoint<'a> {
     StatsUserArtistMap(&'a str),
     StatsUserReleases(&'a str),
     StatsUserArtists(&'a str),
+    StatsReleaseGroupListeners(&'a str),
     StatusGetDumpInfo,
 }
 
@@ -39,6 +40,7 @@ impl<'a> fmt::Display for Endpoint<'a> {
             Self::StatsUserArtistMap(user) => return write!(f, "stats/user/{user}/artist-map"),
             Self::StatsUserReleases(user) => return write!(f, "stats/user/{user}/releases"),
             Self::StatsUserArtists(user) => return write!(f, "stats/user/{user}/artists"),
+            Self::StatsReleaseGroupListeners(release_group_mbid) => return write!(f, "stats/release-group/{release_group_mbid}/listeners"),
             Self::StatusGetDumpInfo => "status/get-dump-info",
         };
         write!(f, "{s}")

--- a/src/raw/response.rs
+++ b/src/raw/response.rs
@@ -490,3 +490,38 @@ response_type! {
         pub timestamp: String,
     }
 }
+
+// ---------- stats/release-group/(release_group_mbid)/listeners
+
+response_type! {
+    /// Response type for [`Client::stats_release_group_listeners`](super::Client::stats_release_group_listeners).
+    #[derive(Debug, Deserialize)]
+    pub struct StatsReleaseGroupListenersResponse {
+        pub payload: StatsReleaseGroupListenersPayload
+    }
+}
+
+/// Type of the [`StatsReleaseGroupListenersResponse::payload`] field.
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+pub struct StatsReleaseGroupListenersPayload {
+    pub artist_mbids: Vec<String>,
+    pub artist_name: String,
+    pub caa_id: Option<i64>,
+    pub caa_release_mbid: Option<String>,
+    pub from_ts: i64,
+    pub last_updated: i64,
+    pub listeners: Vec<StatsReleaseGroupListenersListeners>,
+    pub release_group_mbid: String,
+    pub release_group_name: String,
+    pub stats_range: String,
+    pub to_ts: i64,
+    pub total_listen_count: i64
+}
+
+/// Type of the [`StatsReleaseGroupListenersPayload::listeners`] field.
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+pub struct StatsReleaseGroupListenersListeners {
+    pub listen_count: u64,
+    pub username_name: String,
+}
+


### PR DESCRIPTION
Recreation of #20 due to accidental commits