### PR TITLE
Feature: derive clone + eq for Request and Responce structs

### DIFF
--- a/src/raw/request.rs
+++ b/src/raw/request.rs
@@ -9,14 +9,14 @@ use serde::Serialize;
 // --------- submit-listens
 
 /// Request type for [`Client::submit_listens`](super::Client::submit_listens).
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
 pub struct SubmitListens<'a, Track: StrType, Artist: StrType = Track, Release: StrType = Track> {
     pub listen_type: ListenType,
     pub payload: &'a [Payload<Track, Artist, Release>],
 }
 
 /// Type of the [`SubmitListens::listen_type`] field.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ListenType {
     Single,
@@ -25,7 +25,7 @@ pub enum ListenType {
 }
 
 /// Type of the [`SubmitListens::payload`] field.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
 pub struct Payload<Track: StrType, Artist: StrType = Track, Release: StrType = Track> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub listened_at: Option<i64>,
@@ -35,7 +35,7 @@ pub struct Payload<Track: StrType, Artist: StrType = Track, Release: StrType = T
 /// Type of the [`Payload::track_metadata`] field.
 ///
 /// If [`release_name`](Self::release_name) will always be [None] and the type for `Release` cannot be inferred, set it to the [Empty] type.
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
 pub struct TrackMetadata<Track: StrType, Artist: StrType = Track, Release: StrType = Track> {
     pub track_name: Track,
     pub artist_name: Artist,
@@ -50,7 +50,7 @@ pub struct TrackMetadata<Track: StrType, Artist: StrType = Track, Release: StrTy
 // --------- delete-listen
 
 /// Request type for [`Client::delete_listen`](super::Client::delete_listen).
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
 pub struct DeleteListen<T: StrType> {
     pub listened_at: i64,
     pub recording_msid: T,
@@ -59,7 +59,7 @@ pub struct DeleteListen<T: StrType> {
 // --------- latest-import (POST)
 
 /// Request type for [`Client::update_latest_import`](super::Client::update_latest_import).
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
 pub struct UpdateLatestImport {
     pub ts: i64,
 }

--- a/src/raw/response.rs
+++ b/src/raw/response.rs
@@ -21,7 +21,7 @@ use crate::Error;
 /// as the former is resilient against clients with incorrect clocks.
 ///
 /// [API docs]: https://listenbrainz.readthedocs.io/en/production/dev/api/#rate-limiting
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RateLimit {
     pub limit: u64,
     pub remaining: u64,
@@ -111,7 +111,7 @@ macro_rules! response_type {
 
 response_type! {
     /// Response type for [`Client::submit_listens`](super::Client::submit_listens).
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
     pub struct SubmitListensResponse {
         pub status: String,
     }
@@ -121,7 +121,7 @@ response_type! {
 
 response_type! {
     /// Response type for [`Client::validate_token`](super::Client::validate_token).
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
     pub struct ValidateTokenResponse {
         pub code: u16,
         pub message: String,
@@ -135,7 +135,7 @@ response_type! {
 
 response_type! {
     /// Response type for [`Client::delete_listen`](super::Client::delete_listen).
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
     pub struct DeleteListenResponse {
         pub status: String,
     }
@@ -145,14 +145,14 @@ response_type! {
 
 response_type! {
     /// Response type for [`Client::user_listen_count`](super::Client::user_listen_count).
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
     pub struct UserListenCountResponse {
         pub payload: UserListenCountPayload,
     }
 }
 
 /// Type of the [`UserListenCountResponse::payload`] field.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct UserListenCountPayload {
     pub count: u64,
 }
@@ -161,14 +161,14 @@ pub struct UserListenCountPayload {
 
 response_type! {
     /// Response type for [`Client::user_playing_now`](super::Client::user_playing_now).
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
     pub struct UserPlayingNowResponse {
         pub payload: UserPlayingNowPayload,
     }
 }
 
 /// Type of the [`UserPlayingNowResponse::payload`] field.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct UserPlayingNowPayload {
     pub count: u8,
     pub user_id: String,
@@ -177,14 +177,14 @@ pub struct UserPlayingNowPayload {
 }
 
 /// Type of the [`UserPlayingNowPayload::listens`] field.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct UserPlayingNowListen {
     pub track_metadata: UserPlayingNowTrackMetadata,
     pub playing_now: bool,
 }
 
 /// Type of the [`UserPlayingNowListen::track_metadata`] field.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct UserPlayingNowTrackMetadata {
     pub artist_name: String,
     pub track_name: String,
@@ -196,14 +196,14 @@ pub struct UserPlayingNowTrackMetadata {
 
 response_type! {
     /// Response type for [`Client::user_listens`](super::Client::user_listens).
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
     pub struct UserListensResponse {
         pub payload: UserListensPayload,
     }
 }
 
 /// Type of the [`UserListensResponse::payload`] field.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct UserListensPayload {
     pub count: u64,
     pub latest_listen_ts: i64,
@@ -212,7 +212,7 @@ pub struct UserListensPayload {
 }
 
 /// Type of the [`UserListensPayload::listens`] field.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct UserListensListen {
     pub user_name: String,
     pub inserted_at: i64,
@@ -222,7 +222,7 @@ pub struct UserListensListen {
 }
 
 /// Type of the [`UserListensListen::track_metadata`] field.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct UserListensTrackMetadata {
     pub artist_name: String,
     pub track_name: String,
@@ -234,7 +234,7 @@ pub struct UserListensTrackMetadata {
 
 response_type! {
     /// Response type for [`Client::get_latest_import`](super::Client::get_latest_import).
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
     pub struct GetLatestImportResponse {
         pub latest_import: i64,
         pub musicbrainz_id: String,
@@ -245,7 +245,7 @@ response_type! {
 
 response_type! {
     /// Response type for [`Client::update_latest_import`](super::Client::update_latest_import).
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
     pub struct UpdateLatestImportResponse {
         pub status: String,
     }
@@ -255,14 +255,14 @@ response_type! {
 
 response_type! {
     /// Response type for [`Client::stats_sitewide_artists`](super::Client::stats_sitewide_artists).
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
     pub struct StatsSitewideArtistsResponse {
         pub payload: StatsSitewideArtistsPayload,
     }
 }
 
 /// Type of the [`StatsSitewideArtistsResponse::payload`] field.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct StatsSitewideArtistsPayload {
     pub artists: Vec<StatsSitewideArtistsArtist>,
     pub offset: u64,
@@ -274,7 +274,7 @@ pub struct StatsSitewideArtistsPayload {
 }
 
 /// Type of the [`StatsSitewideArtistsTimeRange::artists`] field.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct StatsSitewideArtistsArtist {
     pub artist_mbids: Option<Vec<String>>,
     pub artist_name: String,
@@ -285,14 +285,14 @@ pub struct StatsSitewideArtistsArtist {
 
 response_type! {
     /// Response type for [`Client::stats_user_listening_activity`](super::Client::stats_user_listening_activity).
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
     pub struct StatsUserListeningActivityResponse {
         pub payload: StatsUserListeningActivityPayload,
     }
 }
 
 /// Type of the [`StatsUserListeningActivityResponse::payload`] field.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct StatsUserListeningActivityPayload {
     pub user_id: String,
     pub listening_activity: Vec<StatsUserListeningActivityListeningActivity>,
@@ -302,7 +302,7 @@ pub struct StatsUserListeningActivityPayload {
 }
 
 /// Type of the [`StatsUserListeningActivityPayload::listening_activity`] field.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct StatsUserListeningActivityListeningActivity {
     pub listen_count: u64,
     pub from_ts: i64,
@@ -314,14 +314,14 @@ pub struct StatsUserListeningActivityListeningActivity {
 
 response_type! {
     /// Response type for [`Client::stats_user_daily_activity`](super::Client::stats_user_daily_activity).
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
     pub struct StatsUserDailyActivityResponse {
         pub payload: StatsUserDailyActivityPayload,
     }
 }
 
 /// Type of the [`StatsUserDailyActivityResponse::payload`] field.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct StatsUserDailyActivityPayload {
     pub user_id: String,
     pub daily_activity: StatsUserDailyActivityDailyActivity,
@@ -332,13 +332,13 @@ pub struct StatsUserDailyActivityPayload {
 }
 
 /// Type of the [`StatsUserDailyActivityPayload::daily_activity`] field.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct StatsUserDailyActivityDailyActivity {
     pub days: HashMap<String, Vec<StatsUserDailyActivityHour>>,
 }
 
 /// Type of the [`StatsUserDailyActivityDailyActivity::days`] field.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct StatsUserDailyActivityHour {
     pub hour: u8,
     pub listen_count: u64,
@@ -348,14 +348,14 @@ pub struct StatsUserDailyActivityHour {
 
 response_type! {
     /// Response type of [`Client::stats_user_recordings`](super::Client::stats_user_recordings).
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
     pub struct StatsUserRecordingsResponse {
         pub payload: StatsUserRecordingsPayload,
     }
 }
 
 /// Type of the [`StatsUserRecordingsResponse::payload`] field.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct StatsUserRecordingsPayload {
     pub recordings: Vec<StatsUserRecordingsRecording>,
     pub count: u64,
@@ -368,7 +368,7 @@ pub struct StatsUserRecordingsPayload {
 }
 
 /// Type of the [`StatsUserRecordingsPayload::recordings`] field.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct StatsUserRecordingsRecording {
     pub artist_mbids: Option<Vec<String>>,
     pub artist_msid: Option<String>,
@@ -386,14 +386,14 @@ pub struct StatsUserRecordingsRecording {
 
 response_type! {
     /// Response type of [`Client::stats_user_artist_map`](super::Client::stats_user_artist_map).
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
     pub struct StatsUserArtistMapResponse {
         pub payload: StatsUserArtistMapPayload,
     }
 }
 
 /// Type of the [`StatsUserArtistMapResponse::payload`] field.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct StatsUserArtistMapPayload {
     pub artist_map: Vec<StatsUserArtistMapCountry>,
     pub user_id: String,
@@ -404,7 +404,7 @@ pub struct StatsUserArtistMapPayload {
 }
 
 /// Type of the [`StatsUserArtistMapPayload::artist_map`] field.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct StatsUserArtistMapCountry {
     pub country: String,
     pub artist_count: u64,
@@ -414,14 +414,14 @@ pub struct StatsUserArtistMapCountry {
 
 response_type! {
     /// Response type for [`Client::stats_user_releases`](super::Client::stats_user_releases).
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
     pub struct StatsUserReleasesResponse {
         pub payload: StatsUserReleasesPayload,
     }
 }
 
 /// Type of the [`StatsUserReleasesResponse::payload`] field.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct StatsUserReleasesPayload {
     pub releases: Vec<StatsUserReleasesRelease>,
     pub count: u64,
@@ -434,7 +434,7 @@ pub struct StatsUserReleasesPayload {
 }
 
 /// Type of the [`StatsUserReleasesPayload::releases`] field.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct StatsUserReleasesRelease {
     pub artist_mbids: Option<Vec<String>>,
     pub artist_msid: Option<String>,
@@ -449,14 +449,14 @@ pub struct StatsUserReleasesRelease {
 
 response_type! {
     /// Response type of [`Client::stats_user_artists`](super::Client::stats_user_artists).
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
     pub struct StatsUserArtistsResponse {
         pub payload: StatsUserArtistsPayload,
     }
 }
 
 /// Type of the [`StatsUserArtistsResponse::payload`] field.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct StatsUserArtistsPayload {
     pub artists: Vec<StatsUserArtistsArtist>,
     pub count: u64,
@@ -469,7 +469,7 @@ pub struct StatsUserArtistsPayload {
 }
 
 /// Type of the [`StatsUserArtistsPayload::artists`] field.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct StatsUserArtistsArtist {
     pub artist_mbids: Option<Vec<String>>,
     pub artist_msid: Option<String>,
@@ -481,7 +481,7 @@ pub struct StatsUserArtistsArtist {
 
 response_type! {
     /// Response type for [`Client::status_get_dump_info`](super::Client::status_get_dump_info).
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
     pub struct StatusGetDumpInfoResponse {
         pub code: u16,
         pub message: String,


### PR DESCRIPTION
I've added the `Clone`, `PartialEq` and `Eq` as talked about in #21. I actually need clone for my app so I did them both at the same time.