### PR TITLE
Pin `rust-version` (MSRV) as per #28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added `Clone`, `PartialEq` and `Eq` derives for `raw` models ([#26], [@RustyNova016]).
 - Removed the `time_range` parameter from `Client::user_listens` ([#24]).
 - Updated attohttpc dependency from 0.24 to 0.28.
+- Pinned the minimum supported Rust version (MSRV) to 1.58.
 
 [#23]: https://github.com/InputUsername/listenbrainz-rs/pull/23
 [#24]: https://github.com/InputUsername/listenbrainz-rs/pull/24

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ description = "ListenBrainz API bindings for Rust"
 keywords = ["listenbrainz", "api", "bindings"]
 categories = ["api-bindings"]
 publish = true
+rust-version = "1.58"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
As per #28, we're looking to pin the MSRV of this crate to allow for older Rust toolchains.

Eventually, we'll add support for MSRV checks in CI, but this sets the first wheels in motion.