### PR TITLE
Added playlist_create body structs

### DIFF
--- a/src/raw/client.rs
+++ b/src/raw/client.rs
@@ -2,7 +2,6 @@ use attohttpc::header::AUTHORIZATION;
 use serde::Serialize;
 
 use super::endpoint::Endpoint;
-use super::jspf;
 use super::request::*;
 use super::response::*;
 use crate::Error;
@@ -295,7 +294,7 @@ impl Client {
     pub fn playlist_create(
         &self,
         token: &str,
-        playlist: jspf::Playlist,
+        playlist: PlaylistCreate,
     ) -> Result<PlaylistCreateResponse, Error> {
         self.post(Endpoint::PlaylistCreate, token, playlist)
     }

--- a/src/raw/jspf.rs
+++ b/src/raw/jspf.rs
@@ -47,13 +47,13 @@ pub struct MusicBrainzPlaylistExtension {
 }
 
 /// Type of the [`MusicBrainzPlaylistExtension::additional_metadata`] field.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct AdditionalMetadata {
     pub algorithm_metadata: Option<AlgorithmMetadata>,
 }
 
 /// Type of the [`AdditionalMetadata::algorithm_metadata`] field.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct AlgorithmMetadata {
     pub source_patch: Option<String>,
 }


### PR DESCRIPTION
The current implementation require a full jspf struct to insert a playlist, while most of that information get discarded.

So I made a series of specialized structs for the creation specifically