### PR TITLE
fix: add missing release fields to `UserListensMBIDMapping`

### DIFF
--- a/src/raw/response.rs
+++ b/src/raw/response.rs
@@ -307,6 +307,9 @@ pub struct UserListensMBIDMapping {
     pub artists: Option<Vec<UserListensMappingArtist>>,
     pub recording_mbid: String,
     pub recording_name: Option<String>,
+    pub caa_id: Option<u64>,
+    pub caa_release_mbid: Option<String>,
+    pub release_mbid: Option<String>,
 }
 
 /// Type of the [`UserListensMBIDMapping::artists`] field.


### PR DESCRIPTION
Those fields are missing in the model structs.