### PR TITLE
fix: added `annotation` to `PlaylistInfo`

### DIFF
--- a/src/raw/jspf.rs
+++ b/src/raw/jspf.rs
@@ -16,6 +16,7 @@ pub struct Playlist {
 /// Type of the [`Playlist::playlist`] field.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct PlaylistInfo {
+    pub annotation: Option<String>,
     pub extension: PlaylistExtension,
     pub creator: String,
     pub date: String,


### PR DESCRIPTION
It's the description of the playlist ;)

Optional as it isn't returned if the description is empty