### PR TITLE
feat: allow choosing TLS provider through features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,19 @@ rust-version = "1.71.1"
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-attohttpc = { version = "0.28", features = ["json"] }
+attohttpc = { version = "0.28", default-features = false, features = ["json", "compress"] }
+
+[features]
+default = ["tls-rustls"]
+
+# Set the TLS to native-tls (Bumps MSRV to >= 1.80.0)
+tls-native = ["attohttpc/tls-native"]
+
+# Set the TLS to native-tls, and use the feature "vendored" (Bumps MSRV to >= 1.80.0)
+tls-native-vendored = ["attohttpc/tls-native-vendored"]
+
+# Use rustls for the TLSwith webpki roots 
+tls-rustls = ["attohttpc/tls-rustls-webpki-roots"]
+
+# Use rustls for the TLS with native roots 
+tls-rustls-native-roots = ["attohttpc/tls-rustls-native-roots"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ tls-native = ["attohttpc/tls-native"]
 # Set the TLS to native-tls, and use the feature "vendored" (Bumps MSRV to >= 1.80.0)
 tls-native-vendored = ["attohttpc/tls-native-vendored"]
 
-# Use rustls for the TLSwith webpki roots 
+# Use rustls for the TLS with webpki roots
 tls-rustls = ["attohttpc/tls-rustls-webpki-roots"]
 
-# Use rustls for the TLS with native roots 
+# Use rustls for the TLS with native roots
 tls-rustls-native-roots = ["attohttpc/tls-rustls-native-roots"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,16 @@
 //! ```
 //!
 //! [Maloja]: https://github.com/krateng/maloja
+//!
+//! # Features
+//!
+//! This crate allows you to control the TLS backend using features:
+//! - `tls-rustls` to use `rustls` with Web PKI roots (**default**)
+//! - `tls-rustls-native-roots` to use `rustls` with root certificates loaded from the rustls-native-certs crate
+//! - `tls-native` to use `native-tls` (requires Rust >= 1.80)
+//! - `tls-native-vendored` to use `native-tls` and activate the `vendored` feature
+//! These are analogous to [attohttpc](https://docs.rs/attohttpc/latest/attohttpc/#features), the
+//! underlying HTTP client.
 
 #![deny(
     missing_docs,


### PR DESCRIPTION
I also set the default to "tls-rustls" instead of the usual "tls-native" to fit the MSRV.
But that can be changed back if bumping the MSRV is prefered

Relevant issue: #47